### PR TITLE
use ring instead of alert with timeout

### DIFF
--- a/app/ui/vibration/index.js
+++ b/app/ui/vibration/index.js
@@ -20,17 +20,14 @@ import { logger } from "../../../common/logger";
 
 export const vibrateSuccess = (vibrateForSeconds = 3) => {
   vibration.stop();
-  logger.vibrate("vibrate: alert");
-  vibration.start("alert");
-  display.poke();
-  setTimeout(() => {
-    logger.vibrate("vibrate: alert stop");
-    vibration.stop();
-  }, vibrateForSeconds * 1000);
+  logger.vibrate("vibrate: success");
+  vibration.start("ring");
 };
 
 export const vibrateFailure = () => {
-  vibrateSuccess(10);
+  vibration.stop();
+  logger.vibrate("vibrate: failure");
+  vibration.start("ring");
 };
 
 export const vibrateInfo = isQuiet => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaf-remote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "license": "Apache 2.0",
   "devDependencies": {


### PR DESCRIPTION
1.2.0 was rejected because of vibration.  Change to use the standard "Ring" for success/failure.