### PR TITLE
Add device tracking

### DIFF
--- a/app/_lib/fitbit/device.js
+++ b/app/_lib/fitbit/device.js
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { me as device } from "device";
+import { trackDevice } from "../google/analytics";
 import { logger } from "../../../common/logger";
 
 export const ifIonic = callback => {
   logger.trace('lib.fitbit.device.touch');
   logger.debug(`device.modelName: ${device.modelName}`);
+  trackDevice(device.modelName);
+
   if (device.modelName === 'Ionic') {
     logger.debug('device: Ionic');
     callback();

--- a/app/_lib/google/analytics.js
+++ b/app/_lib/google/analytics.js
@@ -77,3 +77,12 @@ export const trackButton = buttonAction => {
     event_label: buttonAction
   });
 };
+
+export const trackDevice = deviceType => {
+  analytics.send({
+    hit_type: "event",
+    event_category: "Device",
+    event_action: "Type",
+    event_label: deviceType
+  });
+}

--- a/companion/_lib/fitbit/settings.js
+++ b/companion/_lib/fitbit/settings.js
@@ -62,6 +62,7 @@ const build = () => {
 
     demo: getBoolSetting("demo"),
     debug: getBoolSetting("debug"),
+    disableAnalytics: getBoolSetting("disableAnalytics"),
     disableTouch: getBoolSetting("disableTouch"),
     swapButtons: getBoolSetting("swapButtons"),
     stayAlive: getBoolSetting("stayAlive"),
@@ -70,6 +71,7 @@ const build = () => {
   app = {
     debug: companion.debug,
     demo: companion.demo,
+    disableAnalytics: companion.disableAnalytics,
     disableTouch: companion.disableTouch,
     swapButtons: companion.swapButtons,
     stayAlive: companion.stayAlive,


### PR DESCRIPTION
Track the type of device so we can focus on building features that support our users.